### PR TITLE
Describe command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ hs_err_pid*
 
 *.idea
 *.iml
+
+.classpath
+.project
+.settings
+target

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ cron-utils-cli uses semantic versioning, but since lifecycle does not match the 
 references the tag commit hash in core as metadata in satellite libraries release versions as means to keep traceability
 to the core library.
 
-- Usage: `java -jar cron-utils-cli.jar com.cronutils.cli.CronUtilsCLI --validate -f [CRON4J|QUARTZ|UNIX] -e '<cron expression>'`
+- Usage: `java -jar cron-utils-cli.jar com.cronutils.cli.CronUtilsCLI --validate -f [CRON4J|QUARTZ|UNIX|SPRING] -e '<cron expression>'`
 
 - Example: `java -jar cron-utils-cli.jar com.cronutils.cli.CronUtilsCLI --validate -f UNIX -e '* 1 * * *'`
+
+- Print Description: `java -jar cron-utils-cli.jar com.cronutils.cli.CronUtilsCLI --describe --language en -f UNIX -e '* 1 * * *'`
 
 If you want a standalone jar without requiring the 'cp', build an uber jar with :
 ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     </distributionManagement>
 
     <properties>
-		<cronutils.version>7.0.1</cronutils.version>
+		<cronutils.version>8.0.0</cronutils.version>
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
         <powermock.version>1.6.2</powermock.version>

--- a/src/main/java/com/cronutils/cli/CronUtilsCLI.java
+++ b/src/main/java/com/cronutils/cli/CronUtilsCLI.java
@@ -1,5 +1,11 @@
 package com.cronutils.cli;
 
+import com.cronutils.descriptor.CronDescriptor;
+import com.cronutils.model.Cron;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinition;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.parser.CronParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -7,11 +13,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
-import com.cronutils.model.Cron;
-import com.cronutils.model.CronType;
-import com.cronutils.model.definition.CronDefinition;
-import com.cronutils.model.definition.CronDefinitionBuilder;
-import com.cronutils.parser.CronParser;
+import java.util.Locale;
 
 /*
  * Copyright 2017 bflorat, jmrozanec
@@ -39,6 +41,8 @@ public class CronUtilsCLI {
     private static void cronValidation(String[] args) throws ParseException {
         Options options = new Options();
         options.addOption("v", "validate", false, "Action of validation (default)");
+        options.addOption("d", "describe", false, "Action of describe");
+        options.addOption("l", "language", true, "The language of the description. Example: en");
         options.addOption("f", "format", true,
                 "Cron expression format to validate. Possible values are: CRON4J, QUARTZ, UNIX");
         options.addOption("e", "expression", true, "Cron expression to validate. Example: '* 1 * * *'");
@@ -58,15 +62,32 @@ public class CronUtilsCLI {
             return;
         }
         if (cmd.hasOption('v')) {
-            String format = cmd.getOptionValue("f");
-            String expression = cmd.getOptionValue("e");
-
-            CronType cronType = CronType.valueOf(format);
-            CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(cronType);
-            CronParser cronParser = new CronParser(cronDefinition);
-            Cron quartzCron = cronParser.parse(expression);
-            quartzCron.validate();
+            parseCron(cmd).validate();
         }
+        if (cmd.hasOption('d')) {
+            String language = cmd.getOptionValue("l");
+            CronDescriptor cronDescriptor = CronDescriptor.instance(findLocale(language));
+            System.out.println(cronDescriptor.describe(parseCron(cmd)));
+        }
+    }
+
+    private static Cron parseCron(CommandLine cmd) {
+        String format = cmd.getOptionValue("f");
+        String expression = cmd.getOptionValue("e");
+
+        CronType cronType = CronType.valueOf(format);
+        CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(cronType);
+        CronParser cronParser = new CronParser(cronDefinition);
+        return cronParser.parse(expression);
+    }
+
+    private static Locale findLocale(String code) {
+        for (Locale locale : Locale.getAvailableLocales()) {
+            if (locale.getLanguage().equals(code)) {
+                return locale;
+            }
+        }
+        throw new IllegalStateException("No locale for language " + code);
     }
 
     private static void showHelp(Options options, String header, String footer) {

--- a/src/main/java/com/cronutils/cli/CronUtilsCLI.java
+++ b/src/main/java/com/cronutils/cli/CronUtilsCLI.java
@@ -87,7 +87,7 @@ public class CronUtilsCLI {
                 return locale;
             }
         }
-        throw new IllegalStateException("No locale for language " + code);
+        return Locale.ENGLISH;
     }
 
     private static void showHelp(Options options, String header, String footer) {


### PR DESCRIPTION
added an option `--describe` to print out the description of the cron expression.

language can be specified with `--language`, defaults to english